### PR TITLE
docs: fix highlight for python codeblock

### DIFF
--- a/docs/01-web3-data-api/04-pagination.md
+++ b/docs/01-web3-data-api/04-pagination.md
@@ -9,7 +9,7 @@ Pagination is a way of sorting results by dividing them up into smaller chunks s
 
 ### What is cursor Pagination?
 
-A cursor is a unique identifier (string) for a specific set of records or data chunks, which acts as a pointer to the next set of record we want to fetch from to get the next page of results. Cursor pagination works with O(1) time complexity unlike offset pagination which works O(n) complexity. 
+A cursor is a unique identifier (string) for a specific set of records or data chunks, which acts as a pointer to the next set of record we want to fetch from to get the next page of results. Cursor pagination works with O(1) time complexity unlike offset pagination which works O(n) complexity.
 
 ### Cursor pagination with Moralis API
 
@@ -64,7 +64,7 @@ let owners = {};
 
 Example of using cursor parameter in Python:
 
-```Text Python
+```python
 import requests
 import time
 


### PR DESCRIPTION
Just found the pagination document that is not highlighted because of an invalid code block. This PR fixes that.

Url: http://localhost:3000/web3-data-api/pagination#cursor-pagination-with-moralis-api.

Before

![image](https://user-images.githubusercontent.com/6449655/211740989-f19324ec-603e-43aa-b1cd-ad88e29ecb4e.png)

After

![image](https://user-images.githubusercontent.com/6449655/211741051-fda6b43b-953a-47aa-b43c-bccddc87f098.png)
