### PR TITLE
fix: wagmi no longer exports defaultChains since 0.9.x

### DIFF
--- a/docs/03-authentication-api/tutorials/how-to-authenticate-users-with-metamask-using-react.md
+++ b/docs/03-authentication-api/tutorials/how-to-authenticate-users-with-metamask-using-react.md
@@ -43,7 +43,7 @@ Next we will add the providers required for `wagmi` and `next-auth`.
 2. Open `src/App.js` and add our required imports:
 
 ```javascript
-import { createClient, configureChains, defaultChains, WagmiConfig } from 'wagmi';
+import { createClient, configureChains, WagmiConfig } from 'wagmi';
 import { publicProvider } from 'wagmi/providers/public';
 import { mainnet } from "wagmi/chains";
 

--- a/docs/03-authentication-api/tutorials/how-to-sign-in-with-metamask.md
+++ b/docs/03-authentication-api/tutorials/how-to-sign-in-with-metamask.md
@@ -77,12 +77,7 @@ Every time you modify the `.env.local` file, you need to restart your dapp.
 4. Create the `pages/_app.jsx` file. We need to wrap our pages with `WagmiConfig` ([docs](https://wagmi.sh/docs/WagmiConfig)) and `SessionProvider` ([docs](https://next-auth.js.org/getting-started/client#sessionprovider)):
 
 ```javascript
-import {
-  createClient,
-  configureChains,
-  defaultChains,
-  WagmiConfig,
-} from "wagmi";
+import { createClient, configureChains, WagmiConfig } from "wagmi";
 import { publicProvider } from "wagmi/providers/public";
 import { SessionProvider } from "next-auth/react";
 import { mainnet } from "wagmi/chains";

--- a/docs/03-authentication-api/tutorials/how-to-sign-in-with-rainbowkit.md
+++ b/docs/03-authentication-api/tutorials/how-to-sign-in-with-rainbowkit.md
@@ -23,13 +23,14 @@ npm install @rainbow-me/rainbowkit
 Modify `pages/_app.jsx`:
 
 ```javascript
-import { createClient, configureChains, defaultChains, WagmiConfig } from 'wagmi';
+import { createClient, configureChains, WagmiConfig } from 'wagmi';
 import { publicProvider } from 'wagmi/providers/public';
+import { mainnet } from "wagmi/chains";
 import { SessionProvider } from 'next-auth/react';
 import { getDefaultWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import '@rainbow-me/rainbowkit/styles.css';
 
-const { provider, webSocketProvider, chains } = configureChains(defaultChains, [publicProvider()]);
+const { provider, webSocketProvider, chains } = configureChains([mainnet], [publicProvider()]);
 
 const { connectors } = getDefaultWallets({
     appName: 'My RainbowKit App',


### PR DESCRIPTION
`wagmi` no longer exports `defaultChains` [since 0.9.x](https://wagmi.sh/react/migration-guide#09x-breaking-changes).

The docs also already no longer use `defaultChains` so this import should be removed.