### PR TITLE
updated redirect destination of 5 sources especially with 308->302->200 status redirects

### DIFF
--- a/api/data/redirects.ts
+++ b/api/data/redirects.ts
@@ -2286,7 +2286,7 @@ export const redirects = [
   },
   {
     source: "/cloud-functions-1",
-    destination: "https://v1docs.moralis.io/cloud-functions-1",
+    destination: "https://v1docs.moralis.io/moralis-dapp/cloud-code/cloud-functions",
     permanent: true,
   },
   {
@@ -2551,7 +2551,7 @@ export const redirects = [
   },
   {
     source: "/moralis-sdk/live-queries",
-    destination: "https://v1docs.moralis.io/moralis-sdk/live-queries",
+    destination: "https://v1docs.moralis.io/moralis-dapp/database/live-queries",
     permanent: true,
   },
   {
@@ -2577,7 +2577,7 @@ export const redirects = [
   },
   {
     source: "/moralis-server/web3-sdk",
-    destination: "https://v1docs.moralis.io/moralis-dapp/web3-api",
+    destination: "https://docs.moralis.io/",
     permanent: true,
   },
   {
@@ -2615,7 +2615,7 @@ export const redirects = [
   {
     source: "/guides/build-a-simple-dap-in-3-mins-login-part-2",
     destination:
-      "https://v1docs.moralis.io/guides/build-a-simple-dap-in-3-mins-login-part-2",
+      "https://v1docs.moralis.io/guides/build-a-simple-dapp-in-3-minutes/build-a-simple-dap-in-3-mins-login-part-2",
     permanent: true,
   },
   {
@@ -3607,7 +3607,7 @@ export const redirects = [
   },
   {
     source: "/guides/build-a-simple-dapp-in-3-minutes",
-    destination: "/web3-data-api/getting-started/",
+    destination: "https://v1docs.moralis.io/guides/build-a-simple-dapp-in-3-minutes",
     permanent: true,
   },
   {


### PR DESCRIPTION
This commit tries to reduce multiple redirects which will improve redirect speeds and (hopefully) SEO for the Moralis Webpage. This PR considers that the v1 documentation will not get modified.

The five lines updated in the code notify:

_Status Code(s)
Source
Destination_

Status code: 308, 302
```
/cloud-functions-1
https://v1docs.moralis.io/moralis-dapp/cloud-code/cloud-functions
```
Status code: 308, 302
```
/moralis-sdk/live-queries
https://v1docs.moralis.io/moralis-dapp/database/live-queries
```
Status code: 308, 301
```
/moralis-server/web3-sdk
https://docs.moralis.io/
```

Status Code: 308, 302
```
/guides/build-a-simple-dap-in-3-mins-login-part-2
https://v1docs.moralis.io/guides/build-a-simple-dapp-in-3-minutes/build-a-simple-dap-in-3-mins-login-part-2
```

Status Code: 308, ⚠the redirect works fine but the destination was incorrect in this specific file.
```
/guides/build-a-simple-dapp-in-3-minutes
https://v1docs.moralis.io/guides/build-a-simple-dapp-in-3-minutes
```

**P.S.: I am a beginner in Open Source contributions, so I am all ears for feedback.**