### PR TITLE
update ethers version to support wagmi

### DIFF
--- a/docs/03-authentication-api/tutorials/how-to-authenticate-users-with-metamask-using-react.md
+++ b/docs/03-authentication-api/tutorials/how-to-authenticate-users-with-metamask-using-react.md
@@ -25,7 +25,7 @@ To implement authentication using a Web3 wallet (e.g., MetaMask), we will use a 
 1. Install `wagmi` and `ethers` in your React app:
 
 ```bash npm2yarn
-npm install wagmi ethers
+npm install wagmi ethers@^5
 ```
 
 ## Initial Setup

--- a/docs/03-authentication-api/tutorials/how-to-sign-in-with-metamask-angular.md
+++ b/docs/03-authentication-api/tutorials/how-to-sign-in-with-metamask-angular.md
@@ -23,7 +23,7 @@ To implement authentication using a Web3 wallet (e.g., MetaMask), we will use a 
 1. Install `@wagmi/core`, `ethers`, and `axios` dependencies - [`@wagmi/core@0.5.8`](https://github.com/wagmi-dev/wagmi/releases/tag/%40wagmi%2Fcore%400.5.8) is a stable version we can use with Angular 14:
 
 ```bash npm2yarn
-npm install @wagmi/core@0.5.8 ethers axios
+npm install @wagmi/core@0.5.8 ethers@^5 axios
 ```
 
 2. Open `src/environments/environment.ts` - add a variable of `SERVER_URL` for our server.

--- a/docs/03-authentication-api/tutorials/how-to-sign-in-with-metamask.md
+++ b/docs/03-authentication-api/tutorials/how-to-sign-in-with-metamask.md
@@ -47,7 +47,7 @@ npm install moralis @moralisweb3/next next-auth
 2. To implement authentication using a Web3 wallet (e.g., MetaMask), we need to use a Web3 library. For the tutorial, we will use [wagmi](https://wagmi.sh/docs/getting-started). So, install the `wagmi` dependency:
 
 ```bash npm2yarn
-npm install wagmi ethers
+npm install wagmi ethers@^5
 ```
 
 3. Add new environment variables in your `.env.local` file in the app root:


### PR DESCRIPTION
wagmi requires ethers@^5 to work, it doesnt support 6.x yet so we need ot us 5.x