### PR TITLE
Update cross-chain-requests.md

### DIFF
--- a/docs/01-web3-data-api/evm/developer-tools/cross-chain-requests.md
+++ b/docs/01-web3-data-api/evm/developer-tools/cross-chain-requests.md
@@ -42,20 +42,20 @@ Moralis.EvmApi.block.getBlock({
 | Name                            | Chain id    | EvmChain                  | Type    |
 | :------------------------------ | :---------- | :------------------------ | :------ |
 | Ethereum Mainnet                | 1           | `EvmChain.ETHEREUM`       | Mainnet |
-| Ethereum Ropsten* (deprecated)* | 3           | `EvmChain.ROPSTEN`        | Testnet |
-| Ethereum Rinkeby* (deprecated)* | 4           | `EvmChain.RINKEBY`        | Testnet |
+| Ethereum Ropsten  _(deprecated)_ | 3           | `EvmChain.ROPSTEN`        | Testnet |
+| Ethereum Rinkeby _(deprecated)_ | 4           | `EvmChain.RINKEBY`        | Testnet |
 | Ethereum Görli                  | 5           | `EvmChain.GOERLI`         | Testnet |
-| Ethereum Kovan* (deprecated)*   | 42          | `EvmChain.KOVAN`          | Testnet |
+| Ethereum Kovan _(deprecated)_   | 42          | `EvmChain.KOVAN`          | Testnet |
 | Ethereum Sepolia                | 11155111    | `EvmChain.SEPOLIA`        | Testnet |
 | Polygon Mainnet                 | 137         | `EvmChain.POLYGON`        | Mainnet |
 | Polygon Mumbai                  | 80001       | `EvmChain.MUMBAI`         | Testnet |
 | BNB Mainnet                     | 56          | `EvmChain.BSC`            | Mainnet |
 | BNB Chain Testnet               | 97          | `EvmChain.BSC_TESTNET`    | Testnet |
 | Avalanche C-Chain               | 43114       | `EvmChain.AVALANCHE`      | Mainnet |
-| Avalanche Fuji Testnet          | 43113       | `EvmChain.FUJI`           | Testnet |
+| Avalanche Fuji Testnet _(deprecated)_ | 43113       | `EvmChain.FUJI`           | Testnet |
 | Fantom                          | 250         | `EvmChain.FANTOM`         | Mainnet |
 | Cronos Mainnet                  | 25          | `EvmChain.CRONOS`         | Mainnet |
-| Cronos Testnet                  | 338         | `EvmChain.CRONOS_TESTNET` | Testnet |
+| Cronos Testnet _(deprecated)_ | 338         | `EvmChain.CRONOS_TESTNET` | Testnet |
 | Palm Mainnet                    | 11297108109 | `EvmChain.PALM`           | Mainnet |
 | Arbitrum Mainnet                | 42161       | `EvmChain.ARBITRUM`       | Mainnet |
 


### PR DESCRIPTION
marking cronos and ava testnets as deprecated - please request @YosephKS 