### PR TITLE
change in configs.json

### DIFF
--- a/docs/configs/api-reference/configs.json
+++ b/docs/configs/api-reference/configs.json
@@ -3792,7 +3792,8 @@
           "name": "normalizeMetadata",
           "description": "The option to enable metadata normalization. Learn more about metadata normalization [here](/web3-data-api/evm/normalized-vs-non-normalized-metadata).",
           "required": false,
-          "type": "boolean"
+          "type": "boolean",
+          "example": true
         },
         {
           "name": "media_items",


### PR DESCRIPTION
Update for API "/nft/:address/:token_id"

Added "example": true to query param "normalizeMetadata" as the example response contained normalizeMetadata but if you used example query you will not get normalizeMetadata in real response as in example query normalizeMetadata had no default value.