### PR TITLE
Fixing unclosed square brackets in "NFT metadata upload" code snippet

### DIFF
--- a/docs/01-web3-data-api/evm/ipfs-api/how-to-upload-nft-metadata-to-ipfs.md
+++ b/docs/01-web3-data-api/evm/ipfs-api/how-to-upload-nft-metadata-to-ipfs.md
@@ -62,6 +62,7 @@ const runApp = async () => {
             "trait_type": "Mouth",
             value: "Surprised"
           },
+        ],
       },
     },
 	];
@@ -107,6 +108,7 @@ const runApp = async () => {
             "trait_type": "Mouth",
             value: "Surprised"
           },
+        ],
       },
     },
 	];


### PR DESCRIPTION
This pull request fixes an issue in the code snippet provided in the "How to upload NFT metadata to IPFS" file. The issue was caused by unclosed square brackets in the code, which resulted in a syntax error. I have corrected the code snippet by properly closing the square brackets to ensure its correctness and functionality.