### PR TITLE
chore: fix 404 status URL

### DIFF
--- a/docs/01-web3-data-api/evm/integrations/01-Axelar/bridge-tokens-to-all-chains-with-ITS.md
+++ b/docs/01-web3-data-api/evm/integrations/01-Axelar/bridge-tokens-to-all-chains-with-ITS.md
@@ -986,7 +986,7 @@ You can also explore other functionalities of the Interchain Token Service, such
 - [Ethereum Boilerplate](https://github.com/ethereum-boilerplate/ethereum-boilerplate)
 - [Interchain Token Service Documentation](https://docs.axelar.dev/dev/send-tokens/interchain-tokens/intro)
 - [Interchain Tokens GitHub Repository](https://github.com/axelarnetwork/interchain-token-service/tree/main)
-- [AxelarJS SDK](https://github.com/axelar-network/axelarjs-sdk)
+- [AxelarJS SDK](https://github.com/axelarnetwork/axelarjs-sdk)
 
 ```
 

--- a/docs/01-web3-data-api/evm/integrations/01-Axelar/create-multichain-tokens.md
+++ b/docs/01-web3-data-api/evm/integrations/01-Axelar/create-multichain-tokens.md
@@ -974,4 +974,4 @@ You can also explore other functionalities of the Interchain Token Service, such
 - [Ethereum Boilerplate](https://github.com/ethereum-boilerplate/ethereum-boilerplate)
 - [Interchain Token Service Documentation](https://docs.axelar.dev/dev/send-tokens/interchain-tokens/intro)
 - [Interchain Tokens GitHub Repository](https://github.com/axelarnetwork/interchain-token-service/tree/main)
-- [AxelarJS SDK](https://github.com/axelar-network/axelarjs-sdk)
+- [AxelarJS SDK](https://github.com/axelarnetwork/axelarjs-sdk)


### PR DESCRIPTION
The previous link has expired and has been replaced with the latest address.